### PR TITLE
fix:support for transducer models

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 OpenVoiceOS STT plugin for [Nemo](https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/asr/models.html), GPU is **strongly recommended**
 
-Online demo for [HiTZ/Aholab's Basque Speech-to-Text](https://huggingface.co/spaces/HiTZ/Demo_Basque_ASR)
 
 > **NOTE**: for onnx converted models use [ovos-stt-citrinet-plugin](https://github.com/OpenVoiceOS/ovos-stt-plugin-citrinet) instead
 

--- a/ovos_stt_plugin_nemo/__init__.py
+++ b/ovos_stt_plugin_nemo/__init__.py
@@ -23,7 +23,7 @@ LANG2MODEL = {
     "nl": "stt_nl_citrinet_512_gamma_0_25",
     "uk": "stt_uk_citrinet_512_gamma_0_25",
     "pt": "stt_pt_citrinet_512_gamma_0_25",
-    "eu": "stt_eu_conformer_transducer_large",
+    "eu": "stt_eu_conformer_ctc_large",
     "eo": "stt_eo_conformer_ctc_large",
     "be": "stt_be_conformer_ctc_large",
     "hr": "stt_hr_conformer_ctc_large",
@@ -161,15 +161,3 @@ class NemoSTT(STT):
         return transcriptions[0]
 
 
-if __name__ == "__main__":
-    b = NemoSTT({"lang": "eu"})
-    from speech_recognition import Recognizer, AudioFile
-
-    eu = "/home/miro/PycharmProjects/ovos-stt-nemo-plugin/es.wav"
-    ca = "/home/miro/PycharmProjects/ovos-stt-plugin-vosk/example.wav"
-    with AudioFile(eu) as source:
-        audio = Recognizer().record(source)
-
-    a = b.execute(audio, language="eu")
-    print(a)
-    # asko eskertzen dut nirekin denbora ematea baina orain alde egin behar dut laster zurekin harrapatuko dudala agintzen dizut

--- a/ovos_stt_plugin_nemo/__init__.py
+++ b/ovos_stt_plugin_nemo/__init__.py
@@ -23,7 +23,7 @@ LANG2MODEL = {
     "nl": "stt_nl_citrinet_512_gamma_0_25",
     "uk": "stt_uk_citrinet_512_gamma_0_25",
     "pt": "stt_pt_citrinet_512_gamma_0_25",
-    "eu": "stt_eu_conformer_ctc_large",
+    "eu": "stt_eu_conformer_transducer_large",
     "eo": "stt_eo_conformer_ctc_large",
     "be": "stt_be_conformer_ctc_large",
     "hr": "stt_hr_conformer_ctc_large",
@@ -53,6 +53,7 @@ MODEL2URL = {
     "stt_en_citrinet_1024_gamma_0_25": "https://huggingface.co/nvidia/stt_en_citrinet_1024_gamma_0_25/resolve/main/stt_en_citrinet_1024_gamma_0_25.nemo",
     "stt_zh_citrinet_1024_gamma_0_25": "https://huggingface.co/nvidia/stt_zh_citrinet_1024_gamma_0_25/resolve/main/stt_zh_citrinet_1024_gamma_0_25.nemo",
 
+    "stt_eu_conformer_transducer_large": "https://huggingface.co/HiTZ/stt_eu_conformer_transducer_large/resolve/main/stt_eu_conformer_transducer_large.nemo",
     "stt_eu_conformer_ctc_large": "https://huggingface.co/HiTZ/stt_eu_conformer_ctc_large/resolve/main/stt_eu_conformer_ctc_large.nemo",
     "stt_en_conformer_ctc_small": "https://huggingface.co/nvidia/stt_en_conformer_ctc_small/resolve/main/stt_en_conformer_ctc_small.nemo",
     "stt_en_conformer_ctc_large": "https://huggingface.co/nvidia/stt_en_conformer_ctc_large/resolve/main/stt_en_conformer_ctc_large.nemo",
@@ -103,6 +104,12 @@ class NemoSTT(STT):
             model = LANG2MODEL[lang]
         if not model:
             raise ValueError(f"'lang' {lang} not supported, a 'model' needs to be explicitly set in config file")
+
+        # Load model with CUDA if available
+        import torch
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        if device == "cuda":
+            LOG.debug("Loading nemo model in GPU")
         if model not in PRETRAINED:
             if model in MODEL2URL:
                 model = MODEL2URL[model]
@@ -110,9 +117,11 @@ class NemoSTT(STT):
                 model = self.download(model)
             elif not os.path.isfile(model):
                 raise FileNotFoundError(f"'model' file does not exist - {model}")
+            # the class used here doesnt matter, when restoring from file the correct one is loaded regardless
+            # no need to worry about EncDecRNNTBPEModel vs EncDecCTCModelBPE vs ....
             self.asr_model = nemo_asr.models.EncDecCTCModelBPE.restore_from(model)
         else:
-            self.asr_model = nemo_asr.models.EncDecCTCModel.from_pretrained(model_name=model)
+            self.asr_model = nemo_asr.models.EncDecCTCModel.from_pretrained(model_name=model, map_location=device)
         self.batch_size = self.config.get("batch_size", 8)
 
     @staticmethod
@@ -146,6 +155,9 @@ class NemoSTT(STT):
         if not transcriptions:
             LOG.debug("Transcription is empty")
             return None
+
+        if isinstance(transcriptions[0], list):  # observed in EncDecRNNTBPEModels
+            return transcriptions[0][0]
         return transcriptions[0]
 
 
@@ -153,7 +165,7 @@ if __name__ == "__main__":
     b = NemoSTT({"lang": "eu"})
     from speech_recognition import Recognizer, AudioFile
 
-    eu = "/home/miro/PycharmProjects/ovos-stt-conformer-ctc-plugin/es.wav"
+    eu = "/home/miro/PycharmProjects/ovos-stt-nemo-plugin/es.wav"
     ca = "/home/miro/PycharmProjects/ovos-stt-plugin-vosk/example.wav"
     with AudioFile(eu) as source:
         audio = Recognizer().record(source)


### PR DESCRIPTION
changes default basque model from conformer_ctc to conformer_transducer

fixes some models returning a list instead of a string

replaces https://huggingface.co/HiTZ/stt_eu_conformer_ctc_large with https://huggingface.co/HiTZ/stt_eu_conformer_transducer_large by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the European language model for improved performance.
	- Added a new model URL for the updated European speech-to-text model.
	- Enhanced device management for better GPU utilization during model loading.
	- Expanded the documentation to clarify configuration and model usage.

- **Bug Fixes**
	- Improved transcription handling to accommodate various model output formats.

- **Chores**
	- Updated the file path for audio input to reflect project structure changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->